### PR TITLE
Add environment variables for all config keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ Add `storage` block to file `config.js` in each environment as below:
 
 ## Environment Variables
 
-You can set your connection string as the Environment Variable `AZURE_STORAGE_CONNECTION_STRING`
+You can set your config using the following Environment Variables
+
+ | Config Key       | Environment Variable              |
+ | ---------------- | --------------------------------- |
+ | connectionString | `AZURE_STORAGE_CONNECTION_STRING` |
+ | container        | `AZURE_STORAGE_CONTAINER`         |
+ | cdnUrl           | `AZURE_STORAGE_CDN_URL`           |
+ | useHttps         | `AZURE_STORAGE_USE_HTTPS`         |
+ | cacheControl     | `AZURE_STORAGE_CACHE_CONTROL`     |
+ | useDatedFolder   | `AZURE_STORAGE_USE_DATED_FOLDER`  |
 
 Released under the [MIT license](https://github.com/jldeen/ghost-azurestorage/blob/master/LICENSE).

--- a/index.js
+++ b/index.js
@@ -19,10 +19,11 @@ class AzureStorageAdapter extends BaseStorage {
     options = config || {};
     options.connectionString =
     options.connectionString || process.env.AZURE_STORAGE_CONNECTION_STRING;
-    options.container = options.container || "content";
-    options.useHttps = options.useHttps == "true";
-    options.useDatedFolder = options.useDatedFolder || false;
-    options.cacheControl = options.cacheControl || "2592000";
+    options.container = options.container || process.env.AZURE_STORAGE_CONTAINER || "content";
+    options.cdnUrl = options.cdnUrl || process.env.AZURE_STORAGE_CDN_URL;
+    options.useHttps = (options.useHttps || process.env.AZURE_STORAGE_USE_HTTPS) == "true";
+    options.useDatedFolder = options.useDatedFolder || process.env.AZURE_STORAGE_USE_DATED_FOLDER || false;
+    options.cacheControl = options.cacheControl || process.env.AZURE_STORAGE_CACHE_CONTROL || "2592000";
   }
 
   exists(filename) {


### PR DESCRIPTION
I've configured my ghost instance using a combination of defaults and environment variables up to now but haven't been able to set the CDN url this way.
To get around that I've added support for setting this via an environment variable and also added the other keys in at the same time